### PR TITLE
Scale back default player list to focus on repeat attendees

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,16 +513,11 @@
                     <textarea id="playerNames" rows="8" placeholder="Alice&#10;Bob&#10;Charlie&#10;Diana&#10;Eve">Pratik
 Neha
 Kunjal
-Palak
 Amanda
 Rob
 Courtney
 Taylor
-Steph
-Dana
-Andrew
-Lauren
-Sam</textarea>
+Steph</textarea>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
• Removed 5 players (Palak, Dana, Andrew, Lauren, Sam) from the default player list
• Focused the list on likely repeat attendees to improve default setup experience

## Test plan
- [ ] Verify the default player list now shows 8 players instead of 13
- [ ] Confirm the application loads and functions correctly with the updated list
- [ ] Test that users can still add/remove players as needed

🤖 Generated with [Claude Code](https://claude.ai/code)