### PR TITLE
Add fake minion info templates to Lunatic role

### DIFF
--- a/index.html
+++ b/index.html
@@ -1213,6 +1213,11 @@ Steph</textarea>
                 firstNight: true,
                 otherNights: true,
                 nightActionTemplates: [
+                    // Fake minion info templates (sent first to match timing of real demon's automatic minion info)
+                    ['Your minion is {player1}.'],
+                    ['Your minions are {player1}, {player2}.'],
+                    ['Your minions are {player1}, {player2}, {player3}.'],
+                    // Bluffs template (sent last to match timing of real demon's night action phase)
                     ['These three roles are not in play: {good_role1}, {good_role2}, {good_role3}.'],
                 ]
             },


### PR DESCRIPTION
## Summary
• Added fake minion info templates to the Lunatic role for storyteller use
• Templates match the format sent to real demons (1, 2, or 3 minions)
• Ordered to follow the same timing as real demons: minion info first, then bluffs
• Comments explain the timing logic for future reference

Resolves #22

## Test plan
- [x] Verify Lunatic role shows new minion info templates in night action phase
- [x] Confirm templates allow storyteller to input fake player names
- [x] Test that template ordering matches real demon experience
- [x] Verify existing bluffs template still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)