### PR TITLE
Update CLAUDE-PROMPT-TRANSCRIPT.md with complete conversation history

### DIFF
--- a/CLAUDE-PROMPT-TRANSCRIPT.md
+++ b/CLAUDE-PROMPT-TRANSCRIPT.md
@@ -327,4 +327,46 @@ Remove reminder brings up a model with a combo box with all the current reminder
 
      R: please add the ability to track players "ghost votes". A user either has or does not have a ghost vote. there should be a button available to the story teller to toggle the users ghost vote status in the roleassignmentmodal. if a user is dead and has their ghost vote, a ghost emoji should be shown under their role for all users. pay attention to the instructions at the top that say NOTES FOR CLAUDE
 
+     (At this point, the conversation shifted from Claude.ai to Claude Code)
+
+     F: The default player list is too long. Can you remove Palak, Dana, Andrew, Lauren, and Sam from the default player list to focus on repeat attendees?
+
+     F: The Lunatic role thinks they are a Demon and should receive fake minion information from the storyteller. Can you add fake minion info templates to the Lunatic role? They need templates for 1, 2, and 3 minions to match what real demons receive. The fake minion info should be sent first to match timing, followed by the existing bluffs template.
+
+     F: Lets try to address issue 24. Can you give me an idea of how you might choose to break up the index.html file into sensible smaller pieces? For the first pass, I want to make sure that no content is lost, but it is okay if e.g. some of the absurdly long comments were to migrate into separate .txt or .md (Markdown) files.
+
+     F: Actually, I just had a thought: is there any way you could ensure, for the first pass as the factoring, that you literally break things into pieces where all one has to do is concatenate the files in order to recover the original index.html ? That would make it trivial, in these early stages, to verify that this is  pure refacoring. However, I want you think not just accept my idea as immediately possible; make sure the idea has merit before you try to implement it.
+
+     F: is it okay to use the .html file suffix for things that are only fragments of html?
+
+     F: okay. add the files; we will live with the redunancy for now since this is merely an intermediate step that is meant to be easy to verify.
+
+     F: okay. Now, are there any file fragments that do represent complete pieces on their own right now? E.g. is styles.fragment likely to be a valid CSS file?
+
+     F: Here's what I'm thinking: all in the same commit, lets do three things: 1. adjust 03 and 05 fragments to be valid CSS and valid Javascript, respectively, 2. change their file names to end with .css and .js, respectively, 3. change index.html to remove the blocks of CSS and Javascript that correspond to those fragments, and have it import the new .css and .js files added in the commit instead.
+
+     F: shouldn't we be getting rid of that whole `<style>...</style>`, not just the first tag?
+
+     F: we need to get rid of that content. That's the whole point of this exercise. Since its too large for you to replace in one edit, can you make a plan with multiple edits to get rid of the script?
+
+     F: okay, lets follow a similar strategy for the huge comment blocks at the beginning and end of the file: modify 01-notes.txt and 06-html-body-end.fragment so that they hold just the comment content, not the HTML tags. and rename the files if necesary (I think they should probably both be markdown. and their file names can probably be chosen better to reflect what each of them are.) Finally, remove the corresponding comment blocks from the beginning and end of index.html.
+
+     F: Is there a batter name than DEVELOPMENT-HISTORY? Something to reflect that it was meant to actually capture the conversation I had with Claude to generaete the file in the first place?
+
+     F: How about CLAUDE-PROMPT-TRANSCRIPT.md. And for that matter, maybe you can add the prompts we have been using in the conversation to the end of it. But not in this commitl; we will do that in a follow-up commit.
+
+     F: ah crap I just realized that for these commits, my github author metadata did not match what I typically like to use.
+
+     F: so my name is "Felix S Klock II" and my email is <pnkfelix@pnkfx.org>. Please set those globally in the gitconfig. then we'll rewrite the git history to get rewrite all the commits that say Felix Klock <pnkfelix@Mac.localdomain>
+
+     F: can we force push the current state of main to the origin?
+
+     F: okay, lets go back to refactor/split-index-html and push that branch and then open a PR for it. be sure to link to the original issue in the PR description.
+
+     F: oh I think we must have left some files behind.
+
+     F: I already merged the previous PR before I noticed the issue. I think we need to open a fresh PR
+
+     F: acutally, I just realized something: there were other prompts that we failed to capture, because  I had ended my claude code session and started a new one. Can you figure out, from the commit history, what the likely prompts were for those, and insert them in the right place?
+
 -->


### PR DESCRIPTION
## Summary
Completes the prompt transcript documentation by adding missing conversations and current session prompts.

## Changes Made
- **Added transition marker** noting when conversation shifted from Claude.ai to Claude Code
- **Reconstructed missing prompts** from commit history:
  - Player list cleanup request (removing Palak, Dana, Andrew, Lauren, Sam)
  - Lunatic fake minion info templates request
- **Added all current session prompts** from the major refactoring work
- **Maintains chronological order** for complete development narrative

## Context
The transcript was missing some prompts from earlier Claude Code sessions that occurred between Claude.ai conversations and tonight's refactoring session. By examining the commit history and messages, these have been reconstructed and properly placed in the timeline.

## Result
`CLAUDE-PROMPT-TRANSCRIPT.md` now provides a comprehensive record of the application's evolution:
- Initial Claude.ai conversations for core functionality
- Transition to Claude Code for iterative improvements
- Major refactoring session that split the monolithic index.html

This documentation will be valuable for understanding the development approach and history.

🤖 Generated with [Claude Code](https://claude.ai/code)