### PR TITLE
Complete CLAUDE-PROMPT-TRANSCRIPT.md with final session documentation

### DIFF
--- a/CLAUDE-PROMPT-TRANSCRIPT.md
+++ b/CLAUDE-PROMPT-TRANSCRIPT.md
@@ -369,4 +369,16 @@ Remove reminder brings up a model with a combo box with all the current reminder
 
      F: acutally, I just realized something: there were other prompts that we failed to capture, because  I had ended my claude code session and started a new one. Can you figure out, from the commit history, what the likely prompts were for those, and insert them in the right place?
 
+     F: you can elide the prompts that were just me confirming your presented plan of action.
+
+     F: for these edits, don't include the prefix " Look at this code. Pay attention to the instructions for CLAUDE at the top. "; instead, make a note that at this point in the development, the conversation shifted from being one with Claude.ai to a conversation instead with Claude Code.
+
+     F: sure commit it there. and push. and open a PR.
+
+     F: I want you to try to remember, in future Claude Code invocations, that I like to keep track of the non-trivial prompts I give to you in this CLAUDE-PROMPT-TRANSCRIPT.md file. Where can you store that, such that you will remember to look at it and let it inform your future actions?
+
+     F: okay so we should commit this too then?
+
+     F: do we need to update the transcript as well?
+
 -->

--- a/DEVELOPMENT-NOTES.md
+++ b/DEVELOPMENT-NOTES.md
@@ -2,6 +2,7 @@
 
 * If you have concrete suggestions for changes, present them as diffs. Do not attempt to present the whole file rewritten, as that wastes tokens.
 * If you make an array expression whose elements are written one-per-line, then prefer to include a trailing comma after the last element.
+* **IMPORTANT**: Maintain the conversation transcript in `CLAUDE-PROMPT-TRANSCRIPT.md` by adding non-trivial prompts from each Claude Code session. This provides valuable development history and context for future work.
 
 ## TODO LIST
 


### PR DESCRIPTION
## Summary
Completes the conversation transcript with the remaining prompts from tonight's refactoring session and adds development instructions for future transcript maintenance.

## Changes Made
- **Added final session prompts** to CLAUDE-PROMPT-TRANSCRIPT.md
- **Added transcript maintenance instruction** to DEVELOPMENT-NOTES.md 
- **Ensures accurate documentation** without duplicates

## Context
PR #31 was merged before these final updates could be included. This PR captures the remaining conversation and establishes the practice of maintaining the transcript for future Claude Code sessions.

## Files Updated
- `CLAUDE-PROMPT-TRANSCRIPT.md` - Complete conversation record
- `DEVELOPMENT-NOTES.md` - Added instruction for future transcript maintenance

This completes the documentation of tonight's major refactoring session and establishes sustainable practices for future development.

🤖 Generated with [Claude Code](https://claude.ai/code)