### PR TITLE
feat: update transcript and add CLAUDE.md for future workflow

### DIFF
--- a/CLAUDE-PROMPT-TRANSCRIPT.md
+++ b/CLAUDE-PROMPT-TRANSCRIPT.md
@@ -397,4 +397,8 @@ Remove reminder brings up a model with a combo box with all the current reminder
 
      F: update the transcript please.
 
+     (At this point, the conversation shifted from Claude.ai to Claude Code and GitHub Actions)
+
+     F: can you address this? (Issue #33)
+
 -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# Repository-Specific Claude Instructions
+
+## Prompt Transcript Maintenance
+
+When working on this repository, always update the `CLAUDE-PROMPT-TRANSCRIPT.md` file to capture significant human prompts and AI interactions. This file serves as a record of how much work was done by AI versus human input.
+
+### Format Guidelines
+- Use "F:" prefix for human prompts from Felix
+- Add context about the conversation medium (Claude.ai, Claude Code, GitHub Action)
+- Include brief descriptions of completed work when relevant
+- Maintain chronological order
+- You can elide confirmatory prompts that just approved a presented plan
+
+### When to Update
+- After implementing significant features or fixes
+- When addressing GitHub issues with @claude mentions  
+- Before creating pull requests for substantial changes
+- When shifting between different Claude interfaces (ai.claude.com, Claude Code, GitHub Actions)
+
+### Example Entry Format
+```
+F: [human prompt description]
+
+(Context: via Claude Code for Issue #XX, resulted in PR #YY)
+```
+
+### Development Notes
+Also reference `DEVELOPMENT-NOTES.md` for additional context about the project's current state and any specific preferences or conventions to follow.
+
+## Project Context
+This is a web-based messaging app for smartphone users called "Scratch on the Smartphone" (originally prototyped as a Blood on the Clocktower game assistant). Key technical details:
+- Single-page web application
+- Uses PubNub for real-time messaging
+- Designed for mobile-friendly use
+- Role-based messaging system for game management


### PR DESCRIPTION
Addresses #issue-47 by:

- Adding missing PR #38 interaction to CLAUDE-PROMPT-TRANSCRIPT.md
- Creating CLAUDE.md with instructions for future Claude interactions
- Establishing systematic approach for maintaining prompt transcript

The CLAUDE.md file ensures future Claude Code invocations will automatically maintain the transcript, solving the workflow maintenance challenge.

Generated with [Claude Code](https://claude.ai/code)