### PR TITLE
Remove 4-space indentation from CLAUDE-PROMPT-TRANSCRIPT.md

### DIFF
--- a/CLAUDE-PROMPT-TRANSCRIPT.md
+++ b/CLAUDE-PROMPT-TRANSCRIPT.md
@@ -1,6 +1,6 @@
-     PROMPT SEQUENCE TO CLAUDE
+ PROMPT SEQUENCE TO CLAUDE
 
-     Project Summary: Local Smartphone Messaging App
+ Project Summary: Local Smartphone Messaging App
 Goal
 Create a web-hosted app for smartphones that allows nearby co-located devices to communicate through short text messages, without going through third-party servers. Key requirements:
 * Works on both iOS Safari and Android Chrome
@@ -38,75 +38,75 @@ To add a little extra context here: I want to prototype the smart phone app quic
 In case its not clear, I do want this to be a single page web app that I can just host on my server.
 
 
-     F: I'm not quite sure if your state machine is set up correctly here. In particular, I was thinking that if the Storyteller has already created the game, then each player should just have to type the correct room id. Once they've typed a correct room id, then they select their name from the list of players associated with that room, and get to join. The way your code seems to be set up, the player is given a button to Generate a New Room, and it never fills the combo box with the names. But maybe I am doing something wrong with my own flow?
+ F: I'm not quite sure if your state machine is set up correctly here. In particular, I was thinking that if the Storyteller has already created the game, then each player should just have to type the correct room id. Once they've typed a correct room id, then they select their name from the list of players associated with that room, and get to join. The way your code seems to be set up, the player is given a button to Generate a New Room, and it never fills the combo box with the names. But maybe I am doing something wrong with my own flow?
 
-     (Claude fixed the above. We then went on a wild goose chase eplorting ways to modularize the code, which is probably important for a long-lived vibe-coded engineering effort, but I eventually recognized as being a bad use of time for this small scale thing.)
-
-
-     F: I'm working on a little prototype. I'm actually pretty happy with it so far. Here's the one big thing that I think is missing: It is meant to capture semi-private messaging between some players in a game. It uses PubNub to deal with sending the messages. (They aren't real secrets.) Here's the problem: I was hoping that if I reloaded the page, and then reconnected to the same room, that I would see my current state reloaded; as in, the past messages that were still accessible via PubNub would load up. Is that not the way that PubNub works? Do the messages disappear from PubNub after a participant observes them? Or do I just need to adjust the code to reload the visible messages when connecting to a running game?
-
-     F: Can you show me the necessary changes as a diff that I would need to apply to the file I showed you?
+ (Claude fixed the above. We then went on a wild goose chase eplorting ways to modularize the code, which is probably important for a long-lived vibe-coded engineering effort, but I eventually recognized as being a bad use of time for this small scale thing.)
 
 
-     F: I'm really happy with your help with this app I'm making. One problem I've noticed (or maybe its deliberate): Each message is showing up twice in a senders view. Its seen once on the recipients view. I assume this is something where the code is probably adding the text to the local buffer based on it being locally typed, and then adding it again when it shows up in the pubnub service. Does that sound plausible? See attached. Also, please show your suggestions on how to change this as diffs against the code.
+ F: I'm working on a little prototype. I'm actually pretty happy with it so far. Here's the one big thing that I think is missing: It is meant to capture semi-private messaging between some players in a game. It uses PubNub to deal with sending the messages. (They aren't real secrets.) Here's the problem: I was hoping that if I reloaded the page, and then reconnected to the same room, that I would see my current state reloaded; as in, the past messages that were still accessible via PubNub would load up. Is that not the way that PubNub works? Do the messages disappear from PubNub after a participant observes them? Or do I just need to adjust the code to reload the visible messages when connecting to a running game?
+
+ F: Can you show me the necessary changes as a diff that I would need to apply to the file I showed you?
 
 
-     F: I don't necessarily want to remove the immediate local display. Could we consider detecting the echo and rendering some kind of annotation on the message showing that it made it to the pubnub service, like a little checkmark or something in the rendering near the timestamp?
-
-     F: Look at this code, especially the todo list at the top of the file.
-
-     F: I'm very concerned about the oddities I'm seeing with the set of players and seeming corruption
-
-     F: Wow that's a lot more code than I was expecting. I'm not terribly familiar wit hthis domain; is there no simpler way to accomplish this?
-
-     F: what's wrong with looking at the timestamps and treating the most recent ones as the source of truth?
-
-     F: Well you don't have to take my word at face value. Is there any potential issue with this approach?
-
-     F: Okay. So what does this fix look like as a diff to the current file?
-
-     F: Hmm. It didn't seem to work; I made a new game with the new code and with a larger player list, but it still seems to inherit the old player set associated with this room.
-
-     F: Why did you reduce the delay?
-
-     F: Can you add the script "Bad Moon Rising" to this code? Please present the change to me as a diff.
-
-     F: Something is wrong with this code. The page is not rendering properly at the outset. All I did was try to add the bad moon rising script but I think I got the syntax wrong.
-
-     F: I want to tackle the role assignment problem. Each player can be associated with a role. That role can change during the game, so part of the interface is a way for the storyteller to select a player and change their role, which will then present a combo box with all the roles from the script. But most of the time, the more important thing is that in the storyteller's view, the storyteller sees every player's current role. (In the player's view, they do not see their role, in part because most players cannot actually be certain what their role is, due to characters like the Drunk, the Lunatic, or the Marionette.)
-
-     F: Look at the attached code and the instructions at the top. Note in particular the "NOTES FOR CLAUDE", those are for you to follow in your responses here. Immediate task: I want to refine how role assignment works. The existing way to edit the assigned roles is fine. However, when the storyteller selects "new game" with a certain script and player count, the first step (before actually going to the message communication screen) is for the storyteller to select the subset of roles from the script that will be put into the current game. There should be a way for the storyteller to hand-pick the selection, or to choose it randomly (and then optionally edit the resulting random choices). If the selection is entirely random, it should follow the distribution of the four role categories that is embedded with the script. If the storyteller hand-edits the distribution, then the rendering should include some kind of feedback hint about whether the current set of chosen roles fits the distribution of categories from the script (but the code should not attempt to prevent the storyteller from deviating from the encoded distribution, since in the end this choice is up to the storyteller).
-
-     F: The "Continue To Game" button does not seem to do anything?
-
-     F: Once the subset of the roles has been selected, they should be distributed to the players when we "Continue To Game"
-
-     F: It doesn't seem like the players are being assigned the roles? E.g. in the list of players in the Storyteller view, below "View Script", it says "no role" for most of the players for me?
-
-     F: I see the message on the console ``Roles distributed: Object { Amanda: "mayor", Rob: "slayer", Courtney: "monk", Taylor: "undertaker", Pratik: "imp", Neha: "fortune_teller", Steph: "spy" } demo-botc-pubnub.html:2403:14'' but the rendered page still doesn't include the assignments (see attached partial screenshot).
-
-     F: I'm sorry, the second diff you shows looks like you're replacing a line of code with the exact same thing?
-
-     F: Look at this code. Keep in mind the instructions for you (Claude) at the beginning. Immediate Task: Explain to me, in english, how the role assignments work. Both the initial selection of the subset of roles from the script to be distributed amongst the players (and thus ideally will be a count that matches the player count), as well as how the role of each player can be changed by the storyteller during the game itself. Explain the representations involved and how they interact. If you see any potential invariants that we might consider documenting, or any inconsistencies in the code that might be a sign of a mistake, point those out too. (This is all me preparing to try to address a problem I am seeing, but I want you to help me understand the overall code control and dataflow first before I embark on that.)
-
-     F: the other thing to note is that a (probably undocumented) part of the intended design is that the same room can be reused for different games. So if you start a new game within a room, the set of players (which can change, but do not have to), and their assigned roles (which again can change, but do not have to), should update accordingly.
-
-     F: Lets add a gameId identifier to the messages. I am not worried about them being forged (in fact I might well want to let them be forged, in order to join a game midstream). So lets have the gameId just be a simple construction that takes the room-name and appends a number, and then each time someone creates a new game, they just increment the number. (I am willing to live with the potential race condition there from two hypothetical storyteller both trying to create a game at the same time; that scenario simply isn't going to arise for my use case.)
-
-     F: Even with these changes, I am still seeing the incorrect role assignments being presented when I join the room. The console messages say the correct role assignments, but the rendered web page does not show it.
+ F: I'm really happy with your help with this app I'm making. One problem I've noticed (or maybe its deliberate): Each message is showing up twice in a senders view. Its seen once on the recipients view. I assume this is something where the code is probably adding the text to the local buffer based on it being locally typed, and then adding it again when it shows up in the pubnub service. Does that sound plausible? See attached. Also, please show your suggestions on how to change this as diffs against the code.
 
 
-     F: Here's a log. I manually swapped in two outsiders and took out two townsfolk. so the end player rendering should show the two outsiders. But it does not. Look at the console log, see the place where the player assignment includes a drunk and a recluse (both outsiders), but that fact is lost in the subsequent console logs.
+ F: I don't necessarily want to remove the immediate local display. Could we consider detecting the echo and rendering some kind of annotation on the message showing that it made it to the pubnub service, like a little checkmark or something in the rendering near the timestamp?
 
-     F: I don't understand, why don't we just ignore messages that don't have gameId's, since we have now added those and should only look at messages with game Id that match?
+ F: Look at this code, especially the todo list at the top of the file.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: The storyteller view seems like its working locally, but the player view does not seem like it is getting the storyteller's messages any more (and likewise the player messages are not making it over the the storyteller view). Did I mess something up with the gameId establishment for players? (They should just look for the most recent game when they connect, and use its game-id. IF a new game id comes in for the room while they are playing, then they should reset themselves to that new game id, since it has invalidated the old one for that room.)
+ F: I'm very concerned about the oddities I'm seeing with the set of players and seeming corruption
 
-     F: Even with those changes: I can connect to the game, and I see the list of players and can choose myself, and I can view the script after I connect. But I do not see any messages that the storyteller sends to me, and the messages I send are not seen by the storyteller.
+ F: Wow that's a lot more code than I was expecting. I'm not terribly familiar wit hthis domain; is there no simpler way to accomplish this?
 
-     F: handleIncomingMessage called: ... currentGameId: undefined
+ F: what's wrong with looking at the timestamps and treating the most recent ones as the source of truth?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: I want to prefill the player list with the following list of people (so that I can stop retyping it every time I test), though the list should remain editable in the product. Here is the list of people:
+ F: Well you don't have to take my word at face value. Is there any potential issue with this approach?
+
+ F: Okay. So what does this fix look like as a diff to the current file?
+
+ F: Hmm. It didn't seem to work; I made a new game with the new code and with a larger player list, but it still seems to inherit the old player set associated with this room.
+
+ F: Why did you reduce the delay?
+
+ F: Can you add the script "Bad Moon Rising" to this code? Please present the change to me as a diff.
+
+ F: Something is wrong with this code. The page is not rendering properly at the outset. All I did was try to add the bad moon rising script but I think I got the syntax wrong.
+
+ F: I want to tackle the role assignment problem. Each player can be associated with a role. That role can change during the game, so part of the interface is a way for the storyteller to select a player and change their role, which will then present a combo box with all the roles from the script. But most of the time, the more important thing is that in the storyteller's view, the storyteller sees every player's current role. (In the player's view, they do not see their role, in part because most players cannot actually be certain what their role is, due to characters like the Drunk, the Lunatic, or the Marionette.)
+
+ F: Look at the attached code and the instructions at the top. Note in particular the "NOTES FOR CLAUDE", those are for you to follow in your responses here. Immediate task: I want to refine how role assignment works. The existing way to edit the assigned roles is fine. However, when the storyteller selects "new game" with a certain script and player count, the first step (before actually going to the message communication screen) is for the storyteller to select the subset of roles from the script that will be put into the current game. There should be a way for the storyteller to hand-pick the selection, or to choose it randomly (and then optionally edit the resulting random choices). If the selection is entirely random, it should follow the distribution of the four role categories that is embedded with the script. If the storyteller hand-edits the distribution, then the rendering should include some kind of feedback hint about whether the current set of chosen roles fits the distribution of categories from the script (but the code should not attempt to prevent the storyteller from deviating from the encoded distribution, since in the end this choice is up to the storyteller).
+
+ F: The "Continue To Game" button does not seem to do anything?
+
+ F: Once the subset of the roles has been selected, they should be distributed to the players when we "Continue To Game"
+
+ F: It doesn't seem like the players are being assigned the roles? E.g. in the list of players in the Storyteller view, below "View Script", it says "no role" for most of the players for me?
+
+ F: I see the message on the console ``Roles distributed: Object { Amanda: "mayor", Rob: "slayer", Courtney: "monk", Taylor: "undertaker", Pratik: "imp", Neha: "fortune_teller", Steph: "spy" } demo-botc-pubnub.html:2403:14'' but the rendered page still doesn't include the assignments (see attached partial screenshot).
+
+ F: I'm sorry, the second diff you shows looks like you're replacing a line of code with the exact same thing?
+
+ F: Look at this code. Keep in mind the instructions for you (Claude) at the beginning. Immediate Task: Explain to me, in english, how the role assignments work. Both the initial selection of the subset of roles from the script to be distributed amongst the players (and thus ideally will be a count that matches the player count), as well as how the role of each player can be changed by the storyteller during the game itself. Explain the representations involved and how they interact. If you see any potential invariants that we might consider documenting, or any inconsistencies in the code that might be a sign of a mistake, point those out too. (This is all me preparing to try to address a problem I am seeing, but I want you to help me understand the overall code control and dataflow first before I embark on that.)
+
+ F: the other thing to note is that a (probably undocumented) part of the intended design is that the same room can be reused for different games. So if you start a new game within a room, the set of players (which can change, but do not have to), and their assigned roles (which again can change, but do not have to), should update accordingly.
+
+ F: Lets add a gameId identifier to the messages. I am not worried about them being forged (in fact I might well want to let them be forged, in order to join a game midstream). So lets have the gameId just be a simple construction that takes the room-name and appends a number, and then each time someone creates a new game, they just increment the number. (I am willing to live with the potential race condition there from two hypothetical storyteller both trying to create a game at the same time; that scenario simply isn't going to arise for my use case.)
+
+ F: Even with these changes, I am still seeing the incorrect role assignments being presented when I join the room. The console messages say the correct role assignments, but the rendered web page does not show it.
+
+
+ F: Here's a log. I manually swapped in two outsiders and took out two townsfolk. so the end player rendering should show the two outsiders. But it does not. Look at the console log, see the place where the player assignment includes a drunk and a recluse (both outsiders), but that fact is lost in the subsequent console logs.
+
+ F: I don't understand, why don't we just ignore messages that don't have gameId's, since we have now added those and should only look at messages with game Id that match?
+
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: The storyteller view seems like its working locally, but the player view does not seem like it is getting the storyteller's messages any more (and likewise the player messages are not making it over the the storyteller view). Did I mess something up with the gameId establishment for players? (They should just look for the most recent game when they connect, and use its game-id. IF a new game id comes in for the room while they are playing, then they should reset themselves to that new game id, since it has invalidated the old one for that room.)
+
+ F: Even with those changes: I can connect to the game, and I see the list of players and can choose myself, and I can view the script after I connect. But I do not see any messages that the storyteller sends to me, and the messages I send are not seen by the storyteller.
+
+ F: handleIncomingMessage called: ... currentGameId: undefined
+
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: I want to prefill the player list with the following list of people (so that I can stop retyping it every time I test), though the list should remain editable in the product. Here is the list of people:
 Amanda
 Rob
 Pratik
@@ -116,289 +116,289 @@ Courtney
 Taylor
 Steph
 
-     F: Also make the "I am the" default to Player instead of Storyteller
+ F: Also make the "I am the" default to Player instead of Storyteller
 
-     F: And make the game room id default to "botc_ddt"
+ F: And make the game room id default to "botc_ddt"
 
-     F: The game room id ends up overwritten by the random generation. Can I turn that off temporarily?
+ F: The game room id ends up overwritten by the random generation. Can I turn that off temporarily?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: Remove the "Assign Role" button; it is following a separate code path that is causing more harm than good for right now, because the actual roles are assigned via a separate process.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: Remove the "Assign Role" button; it is following a separate code path that is causing more harm than good for right now, because the actual roles are assigned via a separate process.
 
-     F: Now, add a new button, "Distribute Roles", where its effect is to tell *all *the players what their assigned role is, as set in the playerRoles array.
+ F: Now, add a new button, "Distribute Roles", where its effect is to tell *all *the players what their assigned role is, as set in the playerRoles array.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: In this code, I want to add a way to add reminder tokens in the storyteller view. Right now, when I click on a player, it just lets me assign a role or cancel. Change this interface, so that instead of the primary thing being role reassignment (and having an associated combo box right in my face), instead have four buttons: add reminder, remove reminder, change role, and cancel.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: In this code, I want to add a way to add reminder tokens in the storyteller view. Right now, when I click on a player, it just lets me assign a role or cancel. Change this interface, so that instead of the primary thing being role reassignment (and having an associated combo box right in my face), instead have four buttons: add reminder, remove reminder, change role, and cancel.
 Cancel at this level just brings us back to the main view.
 Change role brings up a new modal with the combo box of all the current roles, or cancel.
 Add reminder brings up a new modal with a text field where I as storyteller can add an arbitrary note, or cancel. This arbitrary note, if present, should show up below the current three lines of text (i.e. add space for a fourth line, which is where the reminder tokens go).
 Remove reminder brings up a model with a combo box with all the current reminders, and the user chooses which one to remove (or cancels).
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: In this game, there are certain roles, like "Drunk", "Lunatic", or "Marionette", where part of the point is that the player who is that role does not actually know they have that role, and they get a different token entirely. The storyteller tracks this with reminder tokens. E.g. a player who is a Drunk Librarian will receive the Librarian token, and the storyteller adds a reminder "Is the Drunk" to them. Here's what I want: 1. What's a good name for this characteristic, of a role where the player thinks it is one thing but in reality it is another? 2. Once you think of such a name (and get confirmation from me that it is indeed a good choice of name), add a way to represent this characteristic to the embedded script definition. Most roles will not have this attribute at all, so I think an optional field that, if present, marks this role as being one of these special ones is probably best. Perhaps the optional field should indicate what kind of character they think they are; e.g. the Drunk always thinks it is a Townsfolk, while the Marionette always thinks that it is some Good character (i.e. either Townsfolk or Outsider), and the Lunatic always thinks it is an (Evil) Demon. 3. The reason we are adding this state explicitly is the third change I want you to make: If the user, as storyteller, hits the "Distribute Roles" button while one of the players has actually been assigned one of these roles (rather than the replacement that it is supposed to believe it has), then make the user go through a confirmation step, pointing out the cases of which players have one of these special roles that is meant to be a secret from them, since we do not want to spoil this fun aspect of the game.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: In this game, there are certain roles, like "Drunk", "Lunatic", or "Marionette", where part of the point is that the player who is that role does not actually know they have that role, and they get a different token entirely. The storyteller tracks this with reminder tokens. E.g. a player who is a Drunk Librarian will receive the Librarian token, and the storyteller adds a reminder "Is the Drunk" to them. Here's what I want: 1. What's a good name for this characteristic, of a role where the player thinks it is one thing but in reality it is another? 2. Once you think of such a name (and get confirmation from me that it is indeed a good choice of name), add a way to represent this characteristic to the embedded script definition. Most roles will not have this attribute at all, so I think an optional field that, if present, marks this role as being one of these special ones is probably best. Perhaps the optional field should indicate what kind of character they think they are; e.g. the Drunk always thinks it is a Townsfolk, while the Marionette always thinks that it is some Good character (i.e. either Townsfolk or Outsider), and the Lunatic always thinks it is an (Evil) Demon. 3. The reason we are adding this state explicitly is the third change I want you to make: If the user, as storyteller, hits the "Distribute Roles" button while one of the players has actually been assigned one of these roles (rather than the replacement that it is supposed to believe it has), then make the user go through a confirmation step, pointing out the cases of which players have one of these special roles that is meant to be a secret from them, since we do not want to spoil this fun aspect of the game.
 
-     F: I prefer "believesToBe" or even maybe "misimpression". The problem with all the other alternatives you have listed ("disguise", "masquerade", "appear"), is that they imply that the player knows about the ruse and is acting on it. But that's not the case here; these are all cases (as implied by names like "Lunatic") where the player is meant to think they are something totally different than what they actually are.
+ F: I prefer "believesToBe" or even maybe "misimpression". The problem with all the other alternatives you have listed ("disguise", "masquerade", "appear"), is that they imply that the player knows about the ruse and is acting on it. But that's not the case here; these are all cases (as implied by names like "Lunatic") where the player is meant to think they are something totally different than what they actually are.
 
-     F: I don't see the diff to distrbuteAllRoles. Can you print it here?
+ F: I don't see the diff to distrbuteAllRoles. Can you print it here?
 
-     F: Is confirm a built-in javascript function?
+ F: Is confirm a built-in javascript function?
 
-     F: I'll try this first, I'm hoping this will barely ever matter.
+ F: I'll try this first, I'm hoping this will barely ever matter.
 
-     F: This is great. It made me realize: can we add a similar bit of code that checks, before we distribute the roles, whether two players are being assigned the same role (which is usually but not always a mistake, which I assume could result e.g. from the storyteller swapping a drunk out for a townsfolk without first checking if its a duplicate), and thus make the storyteller confirm before they send out the roles with a duplicate pair in them?
+ F: This is great. It made me realize: can we add a similar bit of code that checks, before we distribute the roles, whether two players are being assigned the same role (which is usually but not always a mistake, which I assume could result e.g. from the storyteller swapping a drunk out for a townsfolk without first checking if its a duplicate), and thus make the storyteller confirm before they send out the roles with a duplicate pair in them?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: For some reason each players name is showing up on two lines out of four lines in the storyteller view. I think we just need: player name, assigned role, and reminders.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: For some reason each players name is showing up on two lines out of four lines in the storyteller view. I think we just need: player name, assigned role, and reminders.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task:  I want to refactor. the way that the embedded script is handled. There should be two separate maps: One should map each role id, such as 'washerwoman', to its corresponding role object. The other map should map each script  id to the corresponding script object the same way this one does here, except that the roles in the script object should just be a list of role ids, rather than inlining the role object. This will allow Dont-Repeat-Yourself coding of the scripts, since I expect the same role to occur in multiple scripts in the general case.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task:  I want to refactor. the way that the embedded script is handled. There should be two separate maps: One should map each role id, such as 'washerwoman', to its corresponding role object. The other map should map each script  id to the corresponding script object the same way this one does here, except that the roles in the script object should just be a list of role ids, rather than inlining the role object. This will allow Dont-Repeat-Yourself coding of the scripts, since I expect the same role to occur in multiple scripts in the general case.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task:  I want to unify the "Give Info" and "Use Ability" buttons into a single "Night Action" button. As part of this, I want to add a field to each role that holds an array of template strings, such that the storyteller, when they hit the "Night Action" button, it will let the storyteller choose which template string is appropriate for the message they want to send at this point. For example, for the washerwoman a potential template string is "Either {player1} or {player2} is the {role}", and so the storyteller, upon choosing that string, will then be prompt to choose player1 (via combo box of all the players) and  player2 (via another instance of the combo box of all the players) and a role (via a third combo box, but this one now has a list of the roles on the script). Feel free to attempt to fill in the template strings for each role in ROLES.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task:  I want to unify the "Give Info" and "Use Ability" buttons into a single "Night Action" button. As part of this, I want to add a field to each role that holds an array of template strings, such that the storyteller, when they hit the "Night Action" button, it will let the storyteller choose which template string is appropriate for the message they want to send at this point. For example, for the washerwoman a potential template string is "Either {player1} or {player2} is the {role}", and so the storyteller, upon choosing that string, will then be prompt to choose player1 (via combo box of all the players) and  player2 (via another instance of the combo box of all the players) and a role (via a third combo box, but this one now has a list of the roles on the script). Feel free to attempt to fill in the template strings for each role in ROLES.
 
-    F: Okay this is close to what I was thinking of. You've even jumped ahead to think about the case where the player on the other end will need to respond to the message. Lets take care of that issue first: the truly general system here, is to have a night action template be an array of strings of length 1 or 2. The first string is the string that is used on the storytellers side, such as you have chosen for washerwoman or empath, where the information flow is solely from storyteller to player.  The second string is used on the player's side: It tells the code on the players end what it should use when composing its own response to  what the storyteller has asked. For example, the fortune teller should have the storyteller template be something like: ["Choose two players tonight", "I choose {player1} and {player2}"]. (Don't try to go all the way to the third part of the conversation where the storyteller then responds to the fortune teller's choice; I will get to that later, but not now.) So, please revise this whole diff to account for what I described here.
+F: Okay this is close to what I was thinking of. You've even jumped ahead to think about the case where the player on the other end will need to respond to the message. Lets take care of that issue first: the truly general system here, is to have a night action template be an array of strings of length 1 or 2. The first string is the string that is used on the storytellers side, such as you have chosen for washerwoman or empath, where the information flow is solely from storyteller to player.  The second string is used on the player's side: It tells the code on the players end what it should use when composing its own response to  what the storyteller has asked. For example, the fortune teller should have the storyteller template be something like: ["Choose two players tonight", "I choose {player1} and {player2}"]. (Don't try to go all the way to the third part of the conversation where the storyteller then responds to the fortune teller's choice; I will get to that later, but not now.) So, please revise this whole diff to account for what I described here.
 
-    F: By the way, are trailing commas legal after the last element in a JavaScript array?
+F: By the way, are trailing commas legal after the last element in a JavaScript array?
 
-    F: Oops I think I made a typo in my attempt to start transcribing your changes to the roles. Can you identify where my mistake(s) are?
+F: Oops I think I made a typo in my attempt to start transcribing your changes to the roles. Can you identify where my mistake(s) are?
 
-    F: How about this version
+F: How about this version
 
-    F: I want the nightActionTemplates to be optional for now.
+F: I want the nightActionTemplates to be optional for now.
 
-    F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: I have added some nightActionTemplates, but I did not yet put in the code that will process them. Can you show me the diff that will add that functionality?
+F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: I have added some nightActionTemplates, but I did not yet put in the code that will process them. Can you show me the diff that will add that functionality?
 
-    F: This is a good start.  But: right now, when  I do a night action, it just says e.g. "Send info to rob" and the combo box. I need a reminder of what the message is going to look like. Could you present things so that the text that surrounds the placeholders shows up around the combo boxes?
+F: This is a good start.  But: right now, when  I do a night action, it just says e.g. "Send info to rob" and the combo box. I need a reminder of what the message is going to look like. Could you present things so that the text that surrounds the placeholders shows up around the combo boxes?
 
-    F: I don't think this is quite what I meant, but I'm not sure yet. Consider if Amanda is. the Washerwoman. Then I want her night action, when I hit the button, to look to me like "Either" [player combo box here] "or" [player combo box here] " is the " [role combo box here]". Of course since this needs to be mobile-friendly, its fine if there are line breaks or if the combo boxes have to be on the their own lines, that is absolutely fine. The more important thing is to use the template to provide the user with a view of what the meaning is of each thing they are choosing, by showing them the surrounding context i.e. the text of the template for the message that will be constructed after they make their picks in the combo boxes.
+F: I don't think this is quite what I meant, but I'm not sure yet. Consider if Amanda is. the Washerwoman. Then I want her night action, when I hit the button, to look to me like "Either" [player combo box here] "or" [player combo box here] " is the " [role combo box here]". Of course since this needs to be mobile-friendly, its fine if there are line breaks or if the combo boxes have to be on the their own lines, that is absolutely fine. The more important thing is to use the template to provide the user with a view of what the meaning is of each thing they are choosing, by showing them the surrounding context i.e. the text of the template for the message that will be constructed after they make their picks in the combo boxes.
 
-    F: sorry to interrupt you, but can you show me the diff relative to this file here: (and I do welcome you identifying potential redundancies. Do try to reuse the existing work that is there. But also, if you can avoid reprinting large blocks of unchanged code in the diffs you construct, that would be nice too.)
+F: sorry to interrupt you, but can you show me the diff relative to this file here: (and I do welcome you identifying potential redundancies. Do try to reuse the existing work that is there. But also, if you can avoid reprinting large blocks of unchanged code in the diffs you construct, that would be nice too.)
 
-    F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: I think something went wrong in my attempt to apply a diff related to night action templates. Can you help me debug this?
+F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: I think something went wrong in my attempt to apply a diff related to night action templates. Can you help me debug this?
 
-    F: what? I thought I have that on line 1943 ...
+F: what? I thought I have that on line 1943 ...
 
-    F: Uncaught SyntaxError: missing } after function bodydemo-botc-pubnub.html:3139:5note: { opened at line 2036, column 35
+F: Uncaught SyntaxError: missing } after function bodydemo-botc-pubnub.html:3139:5note: { opened at line 2036, column 35
 
-    F: weird. emacs is indicating that the parentheses aren't quite right yet. Is there potentially also an undelimited string or something?
+F: weird. emacs is indicating that the parentheses aren't quite right yet. Is there potentially also an undelimited string or something?
 
-    F: Whoa, is '`' a valid quote for JavaScript code?
+F: Whoa, is '`' a valid quote for JavaScript code?
 
-    F: you don't see them in createInlineTemplate ?
+F: you don't see them in createInlineTemplate ?
 
-    F: At this point I think this is more a problem in Emacs than in my code.
+F: At this point I think this is more a problem in Emacs than in my code.
 
-    F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: If there is more than one entry in the nightActionTemplates array, then the night action button for a player with that role should prompt the story teller to pick which template they want, by showing them the first template string in each of the available arrays. For example, for fortune teller, the storyteller should pick whether they are sending the "choose two players" message or the "yes" message or the "no" message.
+F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: If there is more than one entry in the nightActionTemplates array, then the night action button for a player with that role should prompt the story teller to pick which template they want, by showing them the first template string in each of the available arrays. For example, for fortune teller, the storyteller should pick whether they are sending the "choose two players" message or the "yes" message or the "no" message.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: We do not need the "Ask: Choose Player button" anymore. Lets remove it.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: We do not need the "Ask: Choose Player button" anymore. Lets remove it.
 
-     F: Also, when the storyteller is sending a message to a player, do not bother giving the storyteller a preview of the rendered message that will be presented to the player. Its enough to just let the storyteller see what the storyteller needs to fill in, and trust that the embedded roles array is correctly structured.
+ F: Also, when the storyteller is sending a message to a player, do not bother giving the storyteller a preview of the rendered message that will be presented to the player. Its enough to just let the storyteller see what the storyteller needs to fill in, and trust that the embedded roles array is correctly structured.
 
-     F: To be clear: the player will still get their template that they will fill in, right? This only affects the storyteller's preview, right?
+ F: To be clear: the player will still get their template that they will fill in, right? This only affects the storyteller's preview, right?
 
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: When we distribute the roles, in addition to saying to each player what their role is, add an extra sentence after that (in the same message) that just says "You are good." for townsfolk and outsiders, and "You are evil." for minions and the demon. This is just to reenforce what team they are on, since the text they are getting isn't necessarily colored.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: When we distribute the roles, in addition to saying to each player what their role is, add an extra sentence after that (in the same message) that just says "You are good." for townsfolk and outsiders, and "You are evil." for minions and the demon. This is just to reenforce what team they are on, since the text they are getting isn't necessarily colored.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: Add a button to the storyteller's view that toggles between day and night phases (i.e., during the night, which is how the game starts, the button will say "day breaks", and during the day, the button will say "night falls"). The effect this has: When it is night time, the players can see the messages on their screen for this night.  (But not for previous nights.) When it is day time, the players see no messages at all.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: Add a button to the storyteller's view that toggles between day and night phases (i.e., during the night, which is how the game starts, the button will say "day breaks", and during the day, the button will say "night falls"). The effect this has: When it is night time, the players can see the messages on their screen for this night.  (But not for previous nights.) When it is day time, the players see no messages at all.
 
-     F: Uh, I don't think you should toggle based on receiving a 'phase_change' message alone. I mean, its fine to signal that the event occurred, but I think it will be more robust if you add explicit "daybreak" and "nightfall" events (rather than just "phase_change"). That way, if we inadvertantly issue a nightfall or daybreak multiple times ( due to race conditions or a storyteller reconnect, for example), then it will remain an idempotent operation.
+ F: Uh, I don't think you should toggle based on receiving a 'phase_change' message alone. I mean, its fine to signal that the event occurred, but I think it will be more robust if you add explicit "daybreak" and "nightfall" events (rather than just "phase_change"). That way, if we inadvertantly issue a nightfall or daybreak multiple times ( due to race conditions or a storyteller reconnect, for example), then it will remain an idempotent operation.
 
-     F: sorry, I lost track of what the diff was being applied to. what changes remain for me to make to this file (see attachment)
+ F: sorry, I lost track of what the diff was being applied to. what changes remain for me to make to this file (see attachment)
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: The template string system is pretty good. But, we could be a little more fine grained in how we narrow the combo boxes in some cases. In particular, the washerwoman will only see townsfolk, there's no reason to show all the roles on the script in the combo box. Likewise, the librarian will only see outsiders. We do not need to try to encode all of the possible constraints (e.g. some constraints, such as that of Devil's Advocate or Exorcist, are based on game history that I do not want to try to implement). But the highest level constraints, like categories such as townfolk, lets at least put that into place.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: The template string system is pretty good. But, we could be a little more fine grained in how we narrow the combo boxes in some cases. In particular, the washerwoman will only see townsfolk, there's no reason to show all the roles on the script in the combo box. Likewise, the librarian will only see outsiders. We do not need to try to encode all of the possible constraints (e.g. some constraints, such as that of Devil's Advocate or Exorcist, are based on game history that I do not want to try to implement). But the highest level constraints, like categories such as townfolk, lets at least put that into place.
 
-     F: hmm. is an additional field the cleanest option here? I was myself thinking that adding new template categories would look nice.
+ F: hmm. is an additional field the cleanest option here? I was myself thinking that adding new template categories would look nice.
 
-     F: refactor that predicate into an is_role function rather than inlining that disjunction.
+ F: refactor that predicate into an is_role function rather than inlining that disjunction.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: For some reason, when I send notice to e.g. the Washerwoman about what they learn about other players, it is rendering the role with the first letter in lowercase. Is it because it is plugging in the id instead of the name, or something else?
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top. Immediate task: For some reason, when I send notice to e.g. the Washerwoman about what they learn about other players, it is rendering the role with the first letter in lowercase. Is it because it is plugging in the id instead of the name, or something else?
 
-     F: its weird that the lookup by current script wasn't working. Unless it was an artifact of us moving the role objects out of the script in the first place?
+ F: its weird that the lookup by current script wasn't working. Unless it was an artifact of us moving the role objects out of the script in the first place?
 
-     F: hmm. it didn't seem to resolve the problem. But I also am not seeing that console.log output. The current output is unfortunately flooded with all the console.log for each private message that is processed.
+ F: hmm. it didn't seem to resolve the problem. But I also am not seeing that console.log output. The current output is unfortunately flooded with all the console.log for each private message that is processed.
 
-     F: The option values were capitalized in the combo box before, so I'm not sure if that can possibly be the problem.
+ F: The option values were capitalized in the combo box before, so I'm not sure if that can possibly be the problem.
 
-     F: Either Alice or Bob is the washerwoman
+ F: Either Alice or Bob is the washerwoman
 
-     F: sorry, can you print the diff here?
+ F: sorry, can you print the diff here?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top.  Immediate task: I think the code has a premature assumption that for every case of "choose a player", the current player is not a valid option. But this is not generally true; it is only for a few roles, such as the monk. So while we could add a different subtemplate form, such as {other_player}, the template for {player} should absolutely include the current player as an option in the combo box.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top.  Immediate task: I think the code has a premature assumption that for every case of "choose a player", the current player is not a valid option. But this is not generally true; it is only for a few roles, such as the monk. So while we could add a different subtemplate form, such as {other_player}, the template for {player} should absolutely include the current player as an option in the combo box.
 
-     F: is there another instance of the same problem in createResponseUI ?
+ F: is there another instance of the same problem in createResponseUI ?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top.  Immediate task: The players are currently not able to join the room until after the roles have been distributed. But there is no real reason for that limitation that I can see; after the storyteller has created the room and is in the process of selecting roles, we should let the players go ahead and join the room concurrently.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top.  Immediate task: The players are currently not able to join the room until after the roles have been distributed. But there is no real reason for that limitation that I can see; after the storyteller has created the room and is in the process of selecting roles, we should let the players go ahead and join the room concurrently.
 
-     F: I don't think that's the fix; my players still cannot join the room while I am on the role selection screen. Is there something important from the "Continue to Game" button that we need to do as soon as we get to the Role Selection screen?
+ F: I don't think that's the fix; my players still cannot join the room while I am on the role selection screen. Is there something important from the "Continue to Game" button that we need to do as soon as we get to the Role Selection screen?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE at the top.  Immediate task: When I reconnect as the storyteller, I do not get a reconstruction of the game state, even though I think I should be able to derive much of it from the pubnub messages. E.g. the set of players and the messages that I have sent to them and their responses.
+ F: Look at this code. Pay attention to the instructions for CLAUDE at the top.  Immediate task: When I reconnect as the storyteller, I do not get a reconstruction of the game state, even though I think I should be able to derive much of it from the pubnub messages. E.g. the set of players and the messages that I have sent to them and their responses.
 
-     (At this point in development I merged in a collection of hand-written fixes from Rob)
+ (At this point in development I merged in a collection of hand-written fixes from Rob)
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. I want to rename the page from "Blood on the Clocktower" to "Scratch on the Smartphone". Can you do that?
+ F: Look at this code. Pay attention to the instructions for CLAUDE. I want to rename the page from "Blood on the Clocktower" to "Scratch on the Smartphone". Can you do that?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. When the demon is assigned, the way its rendered in the player list is very hard to see. (I think this only affects the Storyteller's view.) Outsiders are also not so easy to see. Image attached. Please revise the color scheme to make the Demon and Outsiders easier for my eyes to see.
+ F: Look at this code. Pay attention to the instructions for CLAUDE. When the demon is assigned, the way its rendered in the player list is very hard to see. (I think this only affects the Storyteller's view.) Outsiders are also not so easy to see. Image attached. Please revise the color scheme to make the Demon and Outsiders easier for my eyes to see.
 
-     F: That is somewhat close to the minion color. Maybe make the minion a little bit more orange so that the demon remains very red?
+ F: That is somewhat close to the minion color. Maybe make the minion a little bit more orange so that the demon remains very red?
 
-     F: No that is too orange
+ F: No that is too orange
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. The interface is a little too crowded right now. We are going to work on resolving that in small pieces. First: Instead of showing all three of the "Night Action", "Distribute Roles", and "Distribute Minion/Demon Info" buttons at once, I want it to: (A.) first just show the "Distribute Roles" button. Then, after that button is hit, (B.) only show two buttons: "Distribute Minion/Demon Info" and "Skip Minion/Demon Info". (The skip button does nothing except go to the next state, described next.) Then, after either of those buttons is hit, then (C.) only show the "Night Action" button. The idea is that the story teller only has one or two of those buttons to hit, and usually it will just be one.
+ F: Look at this code. Pay attention to the instructions for CLAUDE. The interface is a little too crowded right now. We are going to work on resolving that in small pieces. First: Instead of showing all three of the "Night Action", "Distribute Roles", and "Distribute Minion/Demon Info" buttons at once, I want it to: (A.) first just show the "Distribute Roles" button. Then, after that button is hit, (B.) only show two buttons: "Distribute Minion/Demon Info" and "Skip Minion/Demon Info". (The skip button does nothing except go to the next state, described next.) Then, after either of those buttons is hit, then (C.) only show the "Night Action" button. The idea is that the story teller only has one or two of those buttons to hit, and usually it will just be one.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. Currently, the night action for a player with more than one template is awkward for a story teller, because they need to select the template by typing a number on their screen. Can you make the interface something where I hit the template with my finger instead?
+ F: Look at this code. Pay attention to the instructions for CLAUDE. Currently, the night action for a player with more than one template is awkward for a story teller, because they need to select the template by typing a number on their screen. Can you make the interface something where I hit the template with my finger instead?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. Can you make sure that the messages are sorted by timestamp (with most recent at the bottom)? I have seen weird behaviors where players who connect late get the messages in orders that don't match when the storyteller sent them, and I think that is because we are just adding things in the order that we receive them from pubnub, but that does not always correspond to the original order they were sent in (I think).
+ F: Look at this code. Pay attention to the instructions for CLAUDE. Can you make sure that the messages are sorted by timestamp (with most recent at the bottom)? I have seen weird behaviors where players who connect late get the messages in orders that don't match when the storyteller sent them, and I think that is because we are just adding things in the order that we receive them from pubnub, but that does not always correspond to the original order they were sent in (I think).
 
-     F: And the message will still be inserted eagerly when someone sends it, before receiving confirmation of it from pubnub?
+ F: And the message will still be inserted eagerly when someone sends it, before receiving confirmation of it from pubnub?
 
-     F: Who chooses the timestamp that is attached to a message when it is sent? Is the timestamp chosen by the pubnub server, or is it chosen by the javascript vm that is sending the message?
+ F: Who chooses the timestamp that is attached to a message when it is sent? Is the timestamp chosen by the pubnub server, or is it chosen by the javascript vm that is sending the message?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. I am seeing cases where 1. the storyteller hits the "Distribute Roles" button, but 2. a player is getting the console.log output: Message rejected - no matching condition. and no message is displayed for them, even though on the StoryTeller's side, it claims that it sent the message to that Player.
+ F: Look at this code. Pay attention to the instructions for CLAUDE. I am seeing cases where 1. the storyteller hits the "Distribute Roles" button, but 2. a player is getting the console.log output: Message rejected - no matching condition. and no message is displayed for them, even though on the StoryTeller's side, it claims that it sent the message to that Player.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. I want a way to for the storyteller to mark players as being dead, and when a player is marked as dead, it should be reflected on the screens of all the connected players. I will let you decide whether it is better to do it by having all messages carry the lists of "living" and "dead" players (and then have the message processing code update the UI accordingly), or to have a separate message that signals a death. The point is, the UI should be that the StoryTeller can click a player, and in the modal that currently controls reminder tokens and roles, there should be an extra button, where for living players, this new button says "dies" (and when clicked, signals to all player UI's that the selected player is now dead), and for dead players, the new button says "reborn" (and when clicked, signals to all player UI's that the selected player is living by removing the death marker).
+ F: Look at this code. Pay attention to the instructions for CLAUDE. I want a way to for the storyteller to mark players as being dead, and when a player is marked as dead, it should be reflected on the screens of all the connected players. I will let you decide whether it is better to do it by having all messages carry the lists of "living" and "dead" players (and then have the message processing code update the UI accordingly), or to have a separate message that signals a death. The point is, the UI should be that the StoryTeller can click a player, and in the modal that currently controls reminder tokens and roles, there should be an extra button, where for living players, this new button says "dies" (and when clicked, signals to all player UI's that the selected player is now dead), and for dead players, the new button says "reborn" (and when clicked, signals to all player UI's that the selected player is living by removing the death marker).
 
-     F: Can you show me this as a diff, like I asked in the CLAUDE instructions at the top of the file?
+ F: Can you show me this as a diff, like I asked in the CLAUDE instructions at the top of the file?
 
-     F: uh why did you get rid of the roleSelect button in your diff?
+ F: uh why did you get rid of the roleSelect button in your diff?
 
-     F: In addition to the struck-out text (which I like), can you also make it so that players who are dead have a skull emoji on either side of their name? (and obviously when they are reborn the skulls go away)
+ F: In addition to the struck-out text (which I like), can you also make it so that players who are dead have a skull emoji on either side of their name? (and obviously when they are reborn the skulls go away)
 
-     F: next to the view script button, can you print out these pieces of game state: 1. number of living players, 2. votes needed to meet majority of living players. So for example, in an 8 player game with 5 living players, you would now also have the text "living: 5; majority: 3." Note that the storyteller is not a player in this calculation.
+ F: next to the view script button, can you print out these pieces of game state: 1. number of living players, 2. votes needed to meet majority of living players. So for example, in an 8 player game with 5 living players, you would now also have the text "living: 5; majority: 3." Note that the storyteller is not a player in this calculation.
 
-     F: Wait, are you sure about that majority calculation? for 5 living, the majority is 3. But for 4 living, the majority is only 2.
+ F: Wait, are you sure about that majority calculation? for 5 living, the majority is 3. But for 4 living, the majority is only 2.
 
-     F: No, that's not what I asked for.
+ F: No, that's not what I asked for.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. 1. Change the display so that the part at the top that says "Room: XXX" instead shows "GameId: XXX", so that I can better debug what is going on with the current game ID. 2. Make the game id something that the players can click and change, in order for us to resolve mismatches that might accidentally arise in the field. 3. Show the gameId on the role selection screen for the storyteller (since I believe it should be established by that point).
+ F: Look at this code. Pay attention to the instructions for CLAUDE. 1. Change the display so that the part at the top that says "Room: XXX" instead shows "GameId: XXX", so that I can better debug what is going on with the current game ID. 2. Make the game id something that the players can click and change, in order for us to resolve mismatches that might accidentally arise in the field. 3. Show the gameId on the role selection screen for the storyteller (since I believe it should be established by that point).
 
-     F: It doesn't seem like the UI is updating for the player, even though it is getting messages from the storyteller.
+ F: It doesn't seem like the UI is updating for the player, even though it is getting messages from the storyteller.
 
-     F: Hmm. The "View Script" button for a player now says "No script loaded", even though messages are coming through. Let me show you what my current code looks like: (...)
+ F: Hmm. The "View Script" button for a player now says "No script loaded", even though messages are coming through. Let me show you what my current code looks like: (...)
 
-     F: I'm still seeing "No script loaded" when a player hits "View script".
+ F: I'm still seeing "No script loaded" when a player hits "View script".
 
-     F: When the storyteller first hits "Start Game", and thus goes to the role selection screen, does that send out any timestamped messages for the players that they can use to establish the gameId, the script, and the current set of players?
+ F: When the storyteller first hits "Start Game", and thus goes to the role selection screen, does that send out any timestamped messages for the players that they can use to establish the gameId, the script, and the current set of players?
 
-     F: But there's a setTimeout there around the sendGameSetup. Does that delay the action?
+ F: But there's a setTimeout there around the sendGameSetup. Does that delay the action?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. I am going to add a third home-grown script, called "Trouble Babbling". It has the following characters: Noble, Knight, Investigator, Chef, Empath, Fortune Teller, Soldier, Monk, Ravenkeeper, Philosopher, Slayer, Gambler, Gossip, Butler, Drunk, Recluse, Moonchild, Witch, Godfather, Baron, Scarlet Woman, Imp, Yaggababble, Po. Please make the necessary changes. If you do not know some of the characters, look up their ability text on the wiki, for example: https://wiki.bloodontheclocktower.com/Yaggababble
+ F: Look at this code. Pay attention to the instructions for CLAUDE. I am going to add a third home-grown script, called "Trouble Babbling". It has the following characters: Noble, Knight, Investigator, Chef, Empath, Fortune Teller, Soldier, Monk, Ravenkeeper, Philosopher, Slayer, Gambler, Gossip, Butler, Drunk, Recluse, Moonchild, Witch, Godfather, Baron, Scarlet Woman, Imp, Yaggababble, Po. Please make the necessary changes. If you do not know some of the characters, look up their ability text on the wiki, for example: https://wiki.bloodontheclocktower.com/Yaggababble
 
-     F: The yaggababble actually does not choose their kills (see wiki page I linked).
+ F: The yaggababble actually does not choose their kills (see wiki page I linked).
 
-     F: But why are still having the storyteller send a message to the yaggababble asking them to choose a player?
+ F: But why are still having the storyteller send a message to the yaggababble asking them to choose a player?
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. I want each script to have two new fields, named "first_night_order" and "other_night_order". They each indicate which order the roles are visited in. If you are not sure what order to use for a script, ask me and I'll tell you, do not guess.
+ F: Look at this code. Pay attention to the instructions for CLAUDE. I want each script to have two new fields, named "first_night_order" and "other_night_order". They each indicate which order the roles are visited in. If you are not sure what order to use for a script, ask me and I'll tell you, do not guess.
 
-     F: (Felix transcribed the established night orders for TB and BMR, and then fed the LLM the full list of all characters from https://www.reddit.com/r/BloodOnTheClocktower/comments/1ani01x/kitchen_sink_all_roles_night_order/ )
+ F: (Felix transcribed the established night orders for TB and BMR, and then fed the LLM the full list of all characters from https://www.reddit.com/r/BloodOnTheClocktower/comments/1ani01x/kitchen_sink_all_roles_night_order/ )
 
-     F: I don't think Baron needs to be in any night order. Was it on the original list?
+ F: I don't think Baron needs to be in any night order. Was it on the original list?
 
-     F: Scarlet Woman shouldn't be in the first night order either I think.
+ F: Scarlet Woman shouldn't be in the first night order either I think.
 
-     F: Can you go back and double check them all against the original lists I gave, and see if any remaining exceptions you made (analogous to Baron and Scarlet Woman that I had to point out) and point them out to me?
+ F: Can you go back and double check them all against the original lists I gave, and see if any remaining exceptions you made (analogous to Baron and Scarlet Woman that I had to point out) and point them out to me?
 
-     F: Remove Drunk from the night orders. I think Gossip is solely an Other Night, not a First Night.  Moonchild should stay (the Storyteller needs to remember to take that action), Tinker should stay (Storyteller needs to remember to take that action), Minstrel should stay (Storyteller needs to remember to make everyone drunk once night falls); that's why it was first in my list for other nights (but its not in the list for first night).
+ F: Remove Drunk from the night orders. I think Gossip is solely an Other Night, not a First Night.  Moonchild should stay (the Storyteller needs to remember to take that action), Tinker should stay (Storyteller needs to remember to take that action), Minstrel should stay (Storyteller needs to remember to make everyone drunk once night falls); that's why it was first in my list for other nights (but its not in the list for first night).
 
-     F: This looks fine now. Lets add them to the script definitions in the code.
+ F: This looks fine now. Lets add them to the script definitions in the code.
 
-     F: I want it presented to me as a diff. It shouldn't be too long since these should just be lists of role ids.
+ F: I want it presented to me as a diff. It shouldn't be too long since these should just be lists of role ids.
 
-     F: oh those should be removed from the night orders. (I took them out because I took out Spy, and they are too strong on a script without Spy.)
+ F: oh those should be removed from the night orders. (I took them out because I took out Spy, and they are too strong on a script without Spy.)
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. I want to adjust how the player list that is in the combo box works. In particular: On night 1, sort the players to match the first_night_order that is associated with the current script. (That is, look at the roles in the first_night_order; if a player has that role, then the combo box should show that player at that order in the combo box. If no player has the role, then don't worry about that role in terms of how to order the combo box.) Then on subsequent nights (i.e. nights 2 and beyond), use the other_night_order for the script. One last detail: when ordering the combo box, it is very important to make sure that every player is still in the combo box. So for all players that have a role that isn't on the current night order, just add them all to the end of the combo box.
+ F: Look at this code. Pay attention to the instructions for CLAUDE. I want to adjust how the player list that is in the combo box works. In particular: On night 1, sort the players to match the first_night_order that is associated with the current script. (That is, look at the roles in the first_night_order; if a player has that role, then the combo box should show that player at that order in the combo box. If no player has the role, then don't worry about that role in terms of how to order the combo box.) Then on subsequent nights (i.e. nights 2 and beyond), use the other_night_order for the script. One last detail: when ordering the combo box, it is very important to make sure that every player is still in the combo box. So for all players that have a role that isn't on the current night order, just add them all to the end of the combo box.
 
-     F: I think something is wrong. The order I am seeing in the combo box for night one on Trouble Brewing shows the player who has Poisoner first (good), then the player who has Butler, then sometime after that is the player who has Investigator. But the first night order as defined in the script has them in the order poisoner, investigator, butler, so something must be wrong.
+ F: I think something is wrong. The order I am seeing in the combo box for night one on Trouble Brewing shows the player who has Poisoner first (good), then the player who has Butler, then sometime after that is the player who has Investigator. But the first night order as defined in the script has them in the order poisoner, investigator, butler, so something must be wrong.
 
-     F: Okay. This might be fixed. Is there a way we could add a line, like the text "-----", into the combo box when we finish with the established night order and are just adding the remaining players, so that the storyteller can easily tell when they have taken care of everybody?
+ F: Okay. This might be fixed. Is there a way we could add a line, like the text "-----", into the combo box when we finish with the established night order and are just adding the remaining players, so that the storyteller can easily tell when they have taken care of everybody?
 
-     F: No, something is still wrong.  Look at this screen shot. The player order has Amanda, the Slayer, first, then Rob the Imp. But Pratik the Poisoner should be first in the list.
+ F: No, something is still wrong.  Look at this screen shot. The player order has Amanda, the Slayer, first, then Rob the Imp. But Pratik the Poisoner should be first in the list.
 
-     F: (pasted debug output)
+ F: (pasted debug output)
 
-     F: joinGame and updatePlayersList are the only two cases I managed to identify where we are not using the ordered list. Still, they probably should, right? populateTargetPlayerDropdown is only called once, on the StoryTeller reconnection code (which is relatively untested).
+ F: joinGame and updatePlayersList are the only two cases I managed to identify where we are not using the ordered list. Still, they probably should, right? populateTargetPlayerDropdown is only called once, on the StoryTeller reconnection code (which is relatively untested).
 
-     F: Okay. This might be fixed now. The new problem: It doesn't seem like we are using the other_night_order on nights 2 and above.
+ F: Okay. This might be fixed now. The new problem: It doesn't seem like we are using the other_night_order on nights 2 and above.
 
-     F: I'm only seeing "Night order for night 1", not night 2, even though it is night 2. The dayNightCounter says 2.
+ F: I'm only seeing "Night order for night 1", not night 2, even though it is night 2. The dayNightCounter says 2.
 
-     F: Look at this code. Pay attention to the instructions for CLAUDE. When we send out the role assignments, in the same message where you say "You are X, you are Good/Evil." add additional text after that with a transcription of their role's associated ability field, so that the player does not have to look it up in the script.
+ F: Look at this code. Pay attention to the instructions for CLAUDE. When we send out the role assignments, in the same message where you say "You are X, you are Good/Evil." add additional text after that with a transcription of their role's associated ability field, so that the player does not have to look it up in the script.
 
-     F: Please show me the change as a diff.
+ F: Please show me the change as a diff.
 
-     F: Okay. Lets make one more adjustment: for the ability text that ever says night* , expand that out before sending it in the message into night (not the first), since I cannot expect the receiving players to remember what "night*" means. (But leave the ability text in the script definitions alone, since this is standard lingo for Clocktower.)
+ F: Okay. Lets make one more adjustment: for the ability text that ever says night* , expand that out before sending it in the message into night (not the first), since I cannot expect the receiving players to remember what "night*" means. (But leave the ability text in the script definitions alone, since this is standard lingo for Clocktower.)
 
-     TODO: while this does re-establish the set of players, it does not load up past messages that we have sent. Also, we could easily include the player assignments in the pubnub messages for later retrieval in these situations.
+ TODO: while this does re-establish the set of players, it does not load up past messages that we have sent. Also, we could easily include the player assignments in the pubnub messages for later retrieval in these situations.
 
-     TODO: it seems like when I send a custom private message to a player it isn't being rendered on the other end. Or maybe the messages aren't being ordered in the way I would expect? 1. They are ending up on the top of the recipients text box, and 2. they might only be showing up after a reconnect, not during a live game. Or maybe I've exhausted what pubnub lets me do with demo accounts. Or is the problem that I have two storytellers connected at the same time...
+ TODO: it seems like when I send a custom private message to a player it isn't being rendered on the other end. Or maybe the messages aren't being ordered in the way I would expect? 1. They are ending up on the top of the recipients text box, and 2. they might only be showing up after a reconnect, not during a live game. Or maybe I've exhausted what pubnub lets me do with demo accounts. Or is the problem that I have two storytellers connected at the same time...
 
-     R: please add the ability to track players "ghost votes". A user either has or does not have a ghost vote. there should be a button available to the story teller to toggle the users ghost vote status in the roleassignmentmodal. if a user is dead and has their ghost vote, a ghost emoji should be shown under their role for all users. pay attention to the instructions at the top that say NOTES FOR CLAUDE
+ R: please add the ability to track players "ghost votes". A user either has or does not have a ghost vote. there should be a button available to the story teller to toggle the users ghost vote status in the roleassignmentmodal. if a user is dead and has their ghost vote, a ghost emoji should be shown under their role for all users. pay attention to the instructions at the top that say NOTES FOR CLAUDE
 
-     (At this point, the conversation shifted from Claude.ai to Claude Code)
+ (At this point, the conversation shifted from Claude.ai to Claude Code)
 
-     F: The default player list is too long. Can you remove Palak, Dana, Andrew, Lauren, and Sam from the default player list to focus on repeat attendees?
+ F: The default player list is too long. Can you remove Palak, Dana, Andrew, Lauren, and Sam from the default player list to focus on repeat attendees?
 
-     F: The Lunatic role thinks they are a Demon and should receive fake minion information from the storyteller. Can you add fake minion info templates to the Lunatic role? They need templates for 1, 2, and 3 minions to match what real demons receive. The fake minion info should be sent first to match timing, followed by the existing bluffs template.
+ F: The Lunatic role thinks they are a Demon and should receive fake minion information from the storyteller. Can you add fake minion info templates to the Lunatic role? They need templates for 1, 2, and 3 minions to match what real demons receive. The fake minion info should be sent first to match timing, followed by the existing bluffs template.
 
-     F: Lets try to address issue 24. Can you give me an idea of how you might choose to break up the index.html file into sensible smaller pieces? For the first pass, I want to make sure that no content is lost, but it is okay if e.g. some of the absurdly long comments were to migrate into separate .txt or .md (Markdown) files.
+ F: Lets try to address issue 24. Can you give me an idea of how you might choose to break up the index.html file into sensible smaller pieces? For the first pass, I want to make sure that no content is lost, but it is okay if e.g. some of the absurdly long comments were to migrate into separate .txt or .md (Markdown) files.
 
-     F: Actually, I just had a thought: is there any way you could ensure, for the first pass as the factoring, that you literally break things into pieces where all one has to do is concatenate the files in order to recover the original index.html ? That would make it trivial, in these early stages, to verify that this is  pure refacoring. However, I want you think not just accept my idea as immediately possible; make sure the idea has merit before you try to implement it.
+ F: Actually, I just had a thought: is there any way you could ensure, for the first pass as the factoring, that you literally break things into pieces where all one has to do is concatenate the files in order to recover the original index.html ? That would make it trivial, in these early stages, to verify that this is  pure refacoring. However, I want you think not just accept my idea as immediately possible; make sure the idea has merit before you try to implement it.
 
-     F: is it okay to use the .html file suffix for things that are only fragments of html?
+ F: is it okay to use the .html file suffix for things that are only fragments of html?
 
-     F: okay. add the files; we will live with the redunancy for now since this is merely an intermediate step that is meant to be easy to verify.
+ F: okay. add the files; we will live with the redunancy for now since this is merely an intermediate step that is meant to be easy to verify.
 
-     F: okay. Now, are there any file fragments that do represent complete pieces on their own right now? E.g. is styles.fragment likely to be a valid CSS file?
+ F: okay. Now, are there any file fragments that do represent complete pieces on their own right now? E.g. is styles.fragment likely to be a valid CSS file?
 
-     F: Here's what I'm thinking: all in the same commit, lets do three things: 1. adjust 03 and 05 fragments to be valid CSS and valid Javascript, respectively, 2. change their file names to end with .css and .js, respectively, 3. change index.html to remove the blocks of CSS and Javascript that correspond to those fragments, and have it import the new .css and .js files added in the commit instead.
+ F: Here's what I'm thinking: all in the same commit, lets do three things: 1. adjust 03 and 05 fragments to be valid CSS and valid Javascript, respectively, 2. change their file names to end with .css and .js, respectively, 3. change index.html to remove the blocks of CSS and Javascript that correspond to those fragments, and have it import the new .css and .js files added in the commit instead.
 
-     F: shouldn't we be getting rid of that whole `<style>...</style>`, not just the first tag?
+ F: shouldn't we be getting rid of that whole `<style>...</style>`, not just the first tag?
 
-     F: we need to get rid of that content. That's the whole point of this exercise. Since its too large for you to replace in one edit, can you make a plan with multiple edits to get rid of the script?
+ F: we need to get rid of that content. That's the whole point of this exercise. Since its too large for you to replace in one edit, can you make a plan with multiple edits to get rid of the script?
 
-     F: okay, lets follow a similar strategy for the huge comment blocks at the beginning and end of the file: modify 01-notes.txt and 06-html-body-end.fragment so that they hold just the comment content, not the HTML tags. and rename the files if necesary (I think they should probably both be markdown. and their file names can probably be chosen better to reflect what each of them are.) Finally, remove the corresponding comment blocks from the beginning and end of index.html.
+ F: okay, lets follow a similar strategy for the huge comment blocks at the beginning and end of the file: modify 01-notes.txt and 06-html-body-end.fragment so that they hold just the comment content, not the HTML tags. and rename the files if necesary (I think they should probably both be markdown. and their file names can probably be chosen better to reflect what each of them are.) Finally, remove the corresponding comment blocks from the beginning and end of index.html.
 
-     F: Is there a batter name than DEVELOPMENT-HISTORY? Something to reflect that it was meant to actually capture the conversation I had with Claude to generaete the file in the first place?
+ F: Is there a batter name than DEVELOPMENT-HISTORY? Something to reflect that it was meant to actually capture the conversation I had with Claude to generaete the file in the first place?
 
-     F: How about CLAUDE-PROMPT-TRANSCRIPT.md. And for that matter, maybe you can add the prompts we have been using in the conversation to the end of it. But not in this commitl; we will do that in a follow-up commit.
+ F: How about CLAUDE-PROMPT-TRANSCRIPT.md. And for that matter, maybe you can add the prompts we have been using in the conversation to the end of it. But not in this commitl; we will do that in a follow-up commit.
 
-     F: ah crap I just realized that for these commits, my github author metadata did not match what I typically like to use.
+ F: ah crap I just realized that for these commits, my github author metadata did not match what I typically like to use.
 
-     F: so my name is "Felix S Klock II" and my email is <pnkfelix@pnkfx.org>. Please set those globally in the gitconfig. then we'll rewrite the git history to get rewrite all the commits that say Felix Klock <pnkfelix@Mac.localdomain>
+ F: so my name is "Felix S Klock II" and my email is <pnkfelix@pnkfx.org>. Please set those globally in the gitconfig. then we'll rewrite the git history to get rewrite all the commits that say Felix Klock <pnkfelix@Mac.localdomain>
 
-     F: can we force push the current state of main to the origin?
+ F: can we force push the current state of main to the origin?
 
-     F: okay, lets go back to refactor/split-index-html and push that branch and then open a PR for it. be sure to link to the original issue in the PR description.
+ F: okay, lets go back to refactor/split-index-html and push that branch and then open a PR for it. be sure to link to the original issue in the PR description.
 
-     F: oh I think we must have left some files behind.
+ F: oh I think we must have left some files behind.
 
-     F: I already merged the previous PR before I noticed the issue. I think we need to open a fresh PR
+ F: I already merged the previous PR before I noticed the issue. I think we need to open a fresh PR
 
-     F: acutally, I just realized something: there were other prompts that we failed to capture, because  I had ended my claude code session and started a new one. Can you figure out, from the commit history, what the likely prompts were for those, and insert them in the right place?
+ F: acutally, I just realized something: there were other prompts that we failed to capture, because  I had ended my claude code session and started a new one. Can you figure out, from the commit history, what the likely prompts were for those, and insert them in the right place?
 
-     F: you can elide the prompts that were just me confirming your presented plan of action.
+ F: you can elide the prompts that were just me confirming your presented plan of action.
 
-     F: for these edits, don't include the prefix " Look at this code. Pay attention to the instructions for CLAUDE at the top. "; instead, make a note that at this point in the development, the conversation shifted from being one with Claude.ai to a conversation instead with Claude Code.
+ F: for these edits, don't include the prefix " Look at this code. Pay attention to the instructions for CLAUDE at the top. "; instead, make a note that at this point in the development, the conversation shifted from being one with Claude.ai to a conversation instead with Claude Code.
 
-     F: sure commit it there. and push. and open a PR.
+ F: sure commit it there. and push. and open a PR.
 
-     F: I want you to try to remember, in future Claude Code invocations, that I like to keep track of the non-trivial prompts I give to you in this CLAUDE-PROMPT-TRANSCRIPT.md file. Where can you store that, such that you will remember to look at it and let it inform your future actions?
+ F: I want you to try to remember, in future Claude Code invocations, that I like to keep track of the non-trivial prompts I give to you in this CLAUDE-PROMPT-TRANSCRIPT.md file. Where can you store that, such that you will remember to look at it and let it inform your future actions?
 
-     F: okay so we should commit this too then?
+ F: okay so we should commit this too then?
 
-     F: do we need to update the transcript as well?
+ F: do we need to update the transcript as well?
 
-     F: that's funny, why did you repeat one of my prompts? Did I actually repeat it to you?
+ F: that's funny, why did you repeat one of my prompts? Did I actually repeat it to you?
 
-     F: lets commit this and push it
+ F: lets commit this and push it
 
-     F: and open a PR
+ F: and open a PR
 
-     F: nah I merged that before these changes landed. I think you need to open a fresh PR against this branch.
+ F: nah I merged that before these changes landed. I think you need to open a fresh PR against this branch.
 
-     F: the TODO list in DEVELOPMENT-NOTES.md has gone pretty out-of-date (it predates the github issues I think). Do you know which ones have been addressed explicitly? Have any become irrelevant?
+ F: the TODO list in DEVELOPMENT-NOTES.md has gone pretty out-of-date (it predates the github issues I think). Do you know which ones have been addressed explicitly? Have any become irrelevant?
 
-     F: lets do 1. and 3. first. We can double-check against the github issue list after we finish that first.
+ F: lets do 1. and 3. first. We can double-check against the github issue list after we finish that first.
 
-     F: okay make a branch, add the change, commit the work, push the branch, make a PR.
+ F: okay make a branch, add the change, commit the work, push the branch, make a PR.
 
-     F: update the transcript please.
+ F: update the transcript please.
 
-     (At this point, the conversation shifted from Claude.ai to Claude Code and GitHub Actions)
+ (At this point, the conversation shifted from Claude.ai to Claude Code and GitHub Actions)
 
-     F: can you address this? (Issue #33)
+ F: can you address this? (Issue #33)
 
 -->


### PR DESCRIPTION
Fixed markdown rendering issue where 4-space indentation was causing content to render as code blocks instead of normal text.

🤖 Generated with [Claude Code](https://claude.ai/code)